### PR TITLE
#fix bug for gbk codec / update to 0.3.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*egg-info/*
+.vscode/*

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,8 @@ import setuptools
 import codecs
 import os
 
-
 def read(fname):
-    return codecs.open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return codecs.open(os.path.join(os.path.dirname(__file__), fname), 'rb', encoding='gb18030', errors='ignore').read()
 
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 setuptools.setup(
     name="colour-printing",
-    version="0.3.13",
+    version="0.3.14",
     author="faithforus",
     author_email="ljunf817@163.com",
     description="colour-printing",


### PR DESCRIPTION
WINDOWS终端安装报错  已修复


```
λ  [master ≡]pip install colour-printing
Collecting colour-printing
  Downloading https://files.pythonhosted.org/packages/d1/d5/be84f4220f08c676e0f8683bc470b7731587af9b15b790e16cb1ed29c6cc/colour-printing-0.3.13.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\YUTIAN~1\AppData\Local\Temp\pip-install-zvdootoy\colour-printing\setup.py", line 16, in <module>
        long_description=read('README.rst'),
      File "C:\Users\YUTIAN~1\AppData\Local\Temp\pip-install-zvdootoy\colour-printing\setup.py", line 7, in read
        return codecs.open(os.path.join(os.path.dirname(__file__), fname)).read()
    UnicodeDecodeError: 'gbk' codec can't decode byte 0xa2 in position 46: illegal multibyte sequence

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in C:\Users\YUTIAN~1\AppData\Local\Temp\pip-install-zvdootoy\colour-printing\
```